### PR TITLE
Fix #8 - Add author, updated date and status to frontmatter

### DIFF
--- a/files/admin/config.yml
+++ b/files/admin/config.yml
@@ -16,7 +16,10 @@ collections:
     slug: "{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
+      - {label: "Author", name: "author", widget: "string", required: false}
       - {label: "Date", name: "date", widget: "datetime"}
+      - {label: "Updated", name: "updated", widget: "datetime", required: false}
+      - {label: "Status", name: "status", widget: "select", options: ["published", "featured", "draft", "private"], required: false}
       - {label: "Tags", name: "tags", widget: "list", required: false}
       - {label: "Category", name: "category", widget: "string", required: false}
       - {label: "Description", name: "description", widget: "string", required: false}
@@ -34,7 +37,10 @@ collections:
     slug: "{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
+      - {label: "Author", name: "author", widget: "string", required: false}
       - {label: "Date", name: "date", widget: "datetime"}
+      - {label: "Updated", name: "updated", widget: "datetime", required: false}
+      - {label: "Status", name: "status", widget: "select", options: ["published", "featured", "draft", "private"], required: false}
       - {label: "Tags", name: "tags", widget: "list", required: false}
       - {label: "Category", name: "category", widget: "string", required: false}
       - {label: "Description", name: "description", widget: "string", required: false}


### PR DESCRIPTION
@Kwpolska I've added author, updated and status. Status uses a selection widget based on the values in the Nikola documentation. I'm not very comfortable with including status, though. Could it create confusion with the Netlify CMS workflow? The admin interface also has a button about publishing status. I'm leaving this to you to decide.